### PR TITLE
👷 Replace Repology with Alpine CDN datasource for package pins

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -6,6 +6,12 @@
   "labels": ["dependencies", "no-stale"],
   "commitMessagePrefix": "⬆️",
   "commitMessageTopic": "{{depName}}",
+  "customDatasources": {
+    "alpine": {
+      "defaultRegistryUrlTemplate": "https://dl-cdn.alpinelinux.org/alpine/v3.24/main/x86_64/",
+      "format": "html"
+    }
+  },
   "customManagers": [
     {
       "customType": "regex",
@@ -25,8 +31,9 @@
         "\\s\\s(?<package>[a-z0-9][a-z0-9-_]+)=(?<currentValue>[a-z0-9-_.]+)\\s+"
       ],
       "versioningTemplate": "loose",
-      "datasourceTemplate": "repology",
-      "depNameTemplate": "alpine_3_24/{{package}}"
+      "datasourceTemplate": "custom.alpine",
+      "depNameTemplate": "alpine_3_24/{{package}}",
+      "extractVersionTemplate": "^{{{package}}}-(?<version>\\d.*)\\.apk$"
     },
     {
       "customType": "regex",
@@ -58,8 +65,16 @@
   ],
   "packageRules": [
     {
-      "matchDatasources": ["repology"],
+      "matchDatasources": ["custom.alpine"],
       "automerge": true
+    },
+    {
+      "description": "Packages that live in the Alpine community repository",
+      "matchDatasources": ["custom.alpine"],
+      "matchPackageNames": ["alpine_3_24/libnsl-dev"],
+      "registryUrls": [
+        "https://dl-cdn.alpinelinux.org/alpine/v3.24/community/x86_64/"
+      ]
     },
     {
       "groupName": "App base image",


### PR DESCRIPTION
# Proposed Changes

> (Describe the changes and rationale behind them)

Renovate's `repology` datasource has stopped resolving Alpine package pins across the organization: every `alpine_3_24/*` lookup returns `no-result`, so Alpine pins are no longer updated at all and builds break whenever upstream moves a pinned package. Repology rate limits its `tools/project-by` endpoint hard, and each run resolves 27 packages through it here.

This applies the same fix that landed on hassio-addons/app-ssh#1119: a Renovate custom datasource that reads Alpine's own package index on `dl-cdn.alpinelinux.org`, which is the same place `apk` installs from. Renovate's `html` format turns each `href` in the directory listing into a version candidate, and `extractVersionTemplate` picks the version per package (the `\d` keeps `nano` from matching `nano-syntax-...` style siblings).

- Dependency names stay `alpine_3_24/<package>`, so PR titles, branch names and the automerge rule are unchanged.
- Custom datasources use `registryStrategy: "first"`, so packages from the `community` repository need a rule pointing at the community index. Derived mechanically from the v3.24 `APKINDEX` files against this Dockerfile, exactly one pinned package lives there: `libnsl-dev`. All other 26 pins are in `main`, and none are missing from both indexes.

Verified by running Renovate against this repository, `docker run ghcr.io/renovatebot/renovate:latest` with `RENOVATE_PLATFORM=local RENOVATE_DRY_RUN=lookup` (v44.82.4):

- `renovate-config-validator` validates the config cleanly
- all 27 Alpine pins are extracted and resolve with a `currentVersion` from the CDN, 26 via the `main` index and 1 (`libnsl-dev`) via `community`, zero `Found no results` in the debug log
- zero Alpine updates are found, which matches an independent diff of every pin against the v3.24 `APKINDEX` files: all 27 pins are current

So no stale pin is blocking anything in this repository right now; this PR only restores Renovate's ability to notice the next one.

Stacked on #380, which migrates `fileMatch` to `managerFilePatterns` in the same file. The diff here is the datasource change only.

## Related Issues

> ([Github link][autolink-references] to related issues or pull requests)

Same change as hassio-addons/app-ssh#1119. Dependency Dashboard: #126.

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/
